### PR TITLE
Group by location in numberVisitsByMonth.sql report

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/fullDataExports/numberVisitsByMonth.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/fullDataExports/numberVisitsByMonth.sql
@@ -2,5 +2,5 @@ select distinct loc.name as Site,MONTH(en.encounter_datetime) as Visit_MM,
 YEAR(en.encounter_datetime) as AAAA,count(distinct en.patient_id) as Count
 FROM openmrs.encounter en, openmrs.location loc
 WHERE en.location_id=loc.location_id
-GROUP BY MONTH(en.encounter_datetime), YEAR(en.encounter_datetime)
-ORDER BY 3 DESC; 
+GROUP BY loc.name, MONTH(en.encounter_datetime), YEAR(en.encounter_datetime)
+ORDER BY 3 DESC;


### PR DESCRIPTION
**numberVisitsByMonth.sql report**

By our understanding, it should display a number of visits grouped by month and then grouped by location.
However, it was not grouped by location.

For example. In 2011-05 there were 2 encounters, one in location_id 896, and one in 1077.
![query_1](https://user-images.githubusercontent.com/8256688/43897428-3efe3e2c-9bdc-11e8-94ff-09194d5da598.png)


The report was returning that both of the encounters were in location_id 1077.
![ss2](https://user-images.githubusercontent.com/8256688/43897433-429d8380-9bdc-11e8-98be-daafe6c42317.png)

**We've fixed it so it displays that one encounter was in location_id 896, one in 1077.**
![ss3](https://user-images.githubusercontent.com/8256688/43897447-49b62be0-9bdc-11e8-85b3-f94b3169bc31.png)

