### PR TITLE
ITOS-289: Adjust Adult 1 Indicator to match latest specs

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
@@ -37,6 +37,7 @@ FROM isanteplus.patient p
     LEFT JOIN isanteplus.patient_dispensing pd ON p.patient_id = pd.patient_id
     INNER JOIN isanteplus.patient_status_arv arv ON p.patient_id = arv.patient_id
 WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
+    AND p.vih_status = '1' -- HIV+ patient
     AND p.patient_id NOT IN (   -- Exclude discontinued (1667), transfer (159492)
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon

--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
@@ -32,6 +32,7 @@ SELECT
 FROM isanteplus.patient p
     LEFT JOIN isanteplus.patient_dispensing pd ON p.patient_id = pd.patient_id
 WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
+    AND p.vih_status = '1' -- HIV+ patient
     AND p.patient_id NOT IN (   -- Exclude discontinued (1667), transfer (159492)
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon

--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
@@ -6,7 +6,9 @@ SELECT
       			AND p.patient_id IN ( SELECT pnv.patient_id FROM isanteplus.patient_visit pnv
       			WHERE pnv.patient_id = p.patient_id
                   AND pnv.encounter_type IN (5, 11) -- Ord. Médicale OR Ord. médicale Pédiatrique
-      			AND TIMESTAMPDIFF(DAY, :currentDate, pnv.visit_date) <= 90)
+      			AND (pnv.visit_date BETWEEN DATE(:currentDate) AND DATE_ADD(DATE(:currentDate), INTERVAL 90 DAY)
+				OR pnv.visit_date BETWEEN DATE_SUB(DATE(:currentDate), INTERVAL 90 DAY) AND DATE(:currentDate)))
+                AND arv.start_date BETWEEN SUBDATE(:currentDate, INTERVAL :period MONTH) AND :currentDate
         ) THEN p.patient_id ELSE null END
     ) AS 'femaleNumerator',
     COUNT(
@@ -16,7 +18,9 @@ SELECT
             AND p.patient_id IN ( SELECT pnv.patient_id FROM isanteplus.patient_visit pnv
             WHERE pnv.patient_id = p.patient_id
                   AND pnv.encounter_type IN (5, 11) -- Ord. Médicale OR Ord. médicale Pédiatrique
-            AND TIMESTAMPDIFF(DAY, :currentDate, pnv.visit_date) <= 90)
+            AND (pnv.visit_date BETWEEN DATE(:currentDate) AND DATE_ADD(DATE(:currentDate), INTERVAL 90 DAY)
+            OR pnv.visit_date BETWEEN DATE_SUB(DATE(:currentDate), INTERVAL 90 DAY) AND DATE(:currentDate)))
+            AND arv.start_date BETWEEN SUBDATE(:currentDate, INTERVAL :period MONTH) AND :currentDate
         ) THEN p.patient_id ELSE null END
     ) AS 'maleNumerator',
     COUNT(
@@ -31,14 +35,48 @@ SELECT
     ) AS 'maleDenominator'
 FROM isanteplus.patient p
     LEFT JOIN isanteplus.patient_dispensing pd ON p.patient_id = pd.patient_id
+    INNER JOIN isanteplus.patient_status_arv arv ON p.patient_id = arv.patient_id
 WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
-    AND p.vih_status = '1' -- HIV+ patient
     AND p.patient_id NOT IN (   -- Exclude discontinued (1667), transfer (159492)
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon
         WHERE discon.reason IN (1667, 159492)
-    ) AND p.patient_id IN (
-        SELECT patient_id
-        FROM isanteplus.patient_status_arv
-        WHERE start_date BETWEEN SUBDATE(:currentDate, INTERVAL :period MONTH) AND :currentDate
-    ) AND TIMESTAMPDIFF(YEAR, p.birthdate, :currentDate) > 14; -- adult
+    ) AND TIMESTAMPDIFF(YEAR, p.birthdate, :currentDate) > 14 -- adult
+    AND p.patient_id NOT IN (
+    SELECT DISTINCT pv.patient_id
+FROM isanteplus.health_qual_patient_visit pv
+WHERE
+pv.patient_id NOT IN (    -- Condition E
+	SELECT DISTINCT plab.patient_id
+	FROM isanteplus.patient_laboratory plab
+	WHERE
+		plab.test_done = 1
+		AND plab.test_id = 844	-- PCR
+		AND plab.test_result = 1301 -- positive
+		AND plab.date_test_done BETWEEN :startDate AND :endDate
+)
+AND pv.age_in_years <= 14 -- An child
+AND ( pv.patient_id IN (  -- Condition D
+		SELECT DISTINCT pp.patient_id
+		FROM isanteplus.patient_prescription pp
+		WHERE pp.rx_or_prophy = 163768 -- prophylaxis
+		AND drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs))
+	OR pv.patient_id IN ( -- Condition B
+		SELECT DISTINCT patient_id
+		FROM isanteplus.pediatric_hiv_visit
+		WHERE actual_vih_status = 1405) -- HIV EXPOSED
+	OR pv.patient_id IN ( -- Condition A PCR result
+		SELECT DISTINCT plab.patient_id
+		FROM isanteplus.patient_laboratory plab
+		WHERE plab.test_done = 1
+			AND plab.test_id = 844	-- PCR
+			AND plab.test_result = 1302 -- negative
+			AND plab.date_test_done < :endDate
+	)
+	OR pv.patient_id IN ( -- Condition A virology test
+		SELECT DISTINCT pvt.patient_id
+		FROM isanteplus.virological_tests pvt
+		WHERE answer_concept_id = 1030
+		AND test_result = 664
+		AND pvt.encounter_date  < :endDate)
+));

--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
@@ -2,13 +2,21 @@ SELECT
     COUNT(
         DISTINCT CASE WHEN (
             p.gender = 'F'
-            AND pd.next_dispensation_date >= :currentDate -- still on ART
+            -- drug order form completed on date X. The date of the drug order form should not surpass the reporting period by more than 90 days.
+      			AND p.patient_id IN ( SELECT pnv.patient_id FROM isanteplus.patient_visit pnv
+      			WHERE pnv.patient_id = p.patient_id
+                  AND pnv.encounter_type IN (5, 11) -- Ord. Médicale OR Ord. médicale Pédiatrique
+      			AND TIMESTAMPDIFF(DAY, :currentDate, pnv.visit_date) <= 90)
         ) THEN p.patient_id ELSE null END
     ) AS 'femaleNumerator',
     COUNT(
         DISTINCT CASE WHEN (
             p.gender = 'M'
-            AND pd.next_dispensation_date >= :currentDate -- still on ART
+            -- drug order form completed on date X. The date of the drug order form should not surpass the reporting period by more than 90 days.
+            AND p.patient_id IN ( SELECT pnv.patient_id FROM isanteplus.patient_visit pnv
+            WHERE pnv.patient_id = p.patient_id
+                  AND pnv.encounter_type IN (5, 11) -- Ord. Médicale OR Ord. médicale Pédiatrique
+            AND TIMESTAMPDIFF(DAY, :currentDate, pnv.visit_date) <= 90)
         ) THEN p.patient_id ELSE null END
     ) AS 'maleNumerator',
     COUNT(
@@ -24,10 +32,10 @@ SELECT
 FROM isanteplus.patient p
     LEFT JOIN isanteplus.patient_dispensing pd ON p.patient_id = pd.patient_id
 WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
-    AND p.patient_id NOT IN (   -- Exclude deceased (159), transfer (159492)
+    AND p.patient_id NOT IN (   -- Exclude discontinued (1667), transfer (159492)
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon
-        WHERE discon.reason IN (159, 159492)
+        WHERE discon.reason IN (1667, 159492)
     ) AND p.patient_id IN (
         SELECT patient_id
         FROM isanteplus.patient_status_arv

--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/retentionOfPatientsOnArt.sql
@@ -41,42 +41,4 @@ WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon
         WHERE discon.reason IN (1667, 159492)
-    ) AND TIMESTAMPDIFF(YEAR, p.birthdate, :currentDate) > 14 -- adult
-    AND p.patient_id NOT IN (
-    SELECT DISTINCT pv.patient_id
-FROM isanteplus.health_qual_patient_visit pv
-WHERE
-pv.patient_id NOT IN (    -- Condition E
-	SELECT DISTINCT plab.patient_id
-	FROM isanteplus.patient_laboratory plab
-	WHERE
-		plab.test_done = 1
-		AND plab.test_id = 844	-- PCR
-		AND plab.test_result = 1301 -- positive
-		AND plab.date_test_done BETWEEN :startDate AND :endDate
-)
-AND pv.age_in_years <= 14 -- An child
-AND ( pv.patient_id IN (  -- Condition D
-		SELECT DISTINCT pp.patient_id
-		FROM isanteplus.patient_prescription pp
-		WHERE pp.rx_or_prophy = 163768 -- prophylaxis
-		AND drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs))
-	OR pv.patient_id IN ( -- Condition B
-		SELECT DISTINCT patient_id
-		FROM isanteplus.pediatric_hiv_visit
-		WHERE actual_vih_status = 1405) -- HIV EXPOSED
-	OR pv.patient_id IN ( -- Condition A PCR result
-		SELECT DISTINCT plab.patient_id
-		FROM isanteplus.patient_laboratory plab
-		WHERE plab.test_done = 1
-			AND plab.test_id = 844	-- PCR
-			AND plab.test_result = 1302 -- negative
-			AND plab.date_test_done < :endDate
-	)
-	OR pv.patient_id IN ( -- Condition A virology test
-		SELECT DISTINCT pvt.patient_id
-		FROM isanteplus.virological_tests pvt
-		WHERE answer_concept_id = 1030
-		AND test_result = 664
-		AND pvt.encounter_date  < :endDate)
-));
+    ) AND TIMESTAMPDIFF(YEAR, p.birthdate, :currentDate) > 14; -- adult


### PR DESCRIPTION
Changes:

- Numerator: instead of "pd.next_dispensation_date" use "drug order form completed on date X".
- Denominator: exclude discontinued instead of deceased, HIV+ Patients only

This indicator needs testing.