### PR TITLE
Health-Qual-Adult-16

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHivOnArtUndetectableViralLoadTest6Months.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHivOnArtUndetectableViralLoadTest6Months.sql
@@ -45,7 +45,7 @@ WHERE
         FROM isanteplus.patient_dispensing pd
         WHERE
             pd.drug_id IN ( SELECT arvd.drug_id FROM isanteplus.arv_drugs arvd)
-            AND pd.dispensation_date <= DATE_SUB(:startDate, INTERVAL 6 MONTH)
+            AND pd.dispensation_date <= DATE_SUB(:endDateDate, INTERVAL 6 MONTH)
     ) AND (
         p.patient_id IN (
             SELECT pv.patient_id
@@ -56,8 +56,14 @@ WHERE
             FROM isanteplus.patient_prescription pp
             WHERE
                 DATE(pp.visit_date) BETWEEN :startDate AND :endDate
-                AND pp.rx_or_prophy = 138405
+
         )
+        OR p.patient_id IN (
+			SELECT plab.patient_id
+            FROM isanteplus.patient_laboratory plab
+            WHERE DATE(plab.visit_date) BETWEEN :startDate AND :endDate
+        )
+        
     ) AND p.patient_id NOT IN ( -- Exclude deceased (159), transfer (159492)
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon


### PR DESCRIPTION
When computing patients who have been on ART for 6months, changed the date filter to use the "endDate" instead of the "startDate" parameter