### PR TITLE
Health-Qual-Adult-14

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHivOnArtViralLoadTest6Months.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHivOnArtViralLoadTest6Months.sql
@@ -51,7 +51,7 @@ WHERE
         FROM isanteplus.patient_dispensing pd
         WHERE
             pd.drug_id IN ( SELECT arvd.drug_id FROM isanteplus.arv_drugs arvd)
-            AND pd.dispensation_date <= DATE_SUB(:startDate, INTERVAL 6 MONTH)
+            AND pd.dispensation_date <= DATE_SUB(:endDate, INTERVAL 6 MONTH)
     )
     AND (
         p.patient_id IN (
@@ -64,8 +64,13 @@ WHERE
             FROM isanteplus.patient_prescription pp
             WHERE
                 DATE(pp.visit_date) BETWEEN :startDate AND :endDate
-                AND pp.rx_or_prophy = 138405
         )
+        OR p.patient_id IN (
+			SELECT plab.patient_id
+            FROM isanteplus.patient_laboratory plab
+            WHERE DATE(plab.visit_date) BETWEEN :startdate AND :endDate        
+        )
+
     )
     AND p.patient_id NOT IN ( -- Exclude deceased (159), transfer (159492)
         SELECT discon.patient_id


### PR DESCRIPTION
When computing patients who have been on ART for 6months, changed the date filter to use the endDate instead of the startDate parameter