### PR TITLE
Health-Qual-Paed-1

### DIFF
--- a/api/src/main/java/org/openmrs/module/isanteplusreports/healthqual/util/RegisterAllHealthQualReports.java
+++ b/api/src/main/java/org/openmrs/module/isanteplusreports/healthqual/util/RegisterAllHealthQualReports.java
@@ -212,7 +212,7 @@ public class RegisterAllHealthQualReports {
     }
 
     private static void healthQualChildrenRegularlyFollowedOnArt() {
-        registerHealthEqualReportWithStartDateAndPeriodParams(PEDIATRIC_1_INDICATOR_SQL, PEDIATRIC_1_INDICATOR_MESSAGE,
+        registerHealthEqualReportWithCurrentDateAndPeriodParams(PEDIATRIC_1_INDICATOR_SQL, PEDIATRIC_1_INDICATOR_MESSAGE,
             HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_1_INDICATOR_UUID);
     }
 

--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/childrenRegularlyFollowedOnArt.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/childrenRegularlyFollowedOnArt.sql
@@ -2,10 +2,9 @@ SELECT
     COUNT( DISTINCT CASE WHEN (
         p.gender = 'F'
         AND (
-            pv.visit_date BETWEEN DATE_SUB(:startDate, INTERVAL :period MONTH) AND :startDate
+            pv.visit_date BETWEEN DATE_SUB(:currentDate, INTERVAL :period MONTH) AND :currentDate  AND pv.encounter_type IN (9,10) -- Paeds initial and followup encounter types
             OR (    -- Pediatric Rx
-                pp.visit_date BETWEEN DATE_SUB(:startDate, INTERVAL :period MONTH) AND :startDate
-                AND pp.rx_or_prophy = 138405
+                pp.visit_date BETWEEN DATE_SUB(:currentDate, INTERVAL :period MONTH) AND :currentDate
             )
         )
     ) THEN p.patient_id else null END
@@ -13,10 +12,9 @@ SELECT
     COUNT( DISTINCT CASE WHEN (
         p.gender = 'M'
         AND (
-            pv.visit_date BETWEEN DATE_SUB(:startDate, INTERVAL :period MONTH) AND :startDate
+            pv.visit_date BETWEEN DATE_SUB(:currentDate, INTERVAL :period MONTH) AND :currentDate  AND pv.encounter_type IN (9,10) -- Paeds initial and followup encounter types
             OR (    -- Pediatric Rx
-                pp.visit_date BETWEEN DATE_SUB(:startDate, INTERVAL :period MONTH) AND :startDate
-                AND pp.rx_or_prophy = 138405
+                pp.visit_date BETWEEN DATE_SUB(:currentDate, INTERVAL :period MONTH) AND :currentDate
             )
         )
     ) THEN p.patient_id else null END
@@ -38,7 +36,8 @@ FROM
     LEFT JOIN isanteplus.patient_prescription pp
         ON poa.patient_id = pp.patient_id
 WHERE
-    p.patient_id NOT IN (        -- excluding 
+    p.vih_status = '1' -- HIV+ patient
+    AND p.patient_id NOT IN (        -- excluding 
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon
         WHERE discon.reason IN (159,1667,159492)


### PR DESCRIPTION
- When computing the numerator, removed the filter " AND pp.rx_or_prophy
= 138405" which seems to not have additional value
- To ensure consistency with other similar queries in the use of parameters, changed the date parameter from "startDate" to "currentDate"
- Also changed the corresponding report definition util method to
reflect the query parameter change.
- When computing the Numerator, Filtered Encounter Type to restrict (Paeds
Initial and follow-up encounters only)
---------------------
Indicator definition
---------------------

>**Proportion of children regularly followed on ART**
> **_Numerator_**: Cumulative number of children on ART who have had at least one visit during the last 3 months.
> **_Calculation method_**: Pediatric HIV+ patients on ART excluding deceased, those who discontinued treatment and those who had a negative PCR result, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the last X months.
> Disaggregation: X = 6 or 12 or 24 or 48 or 60 months
> **_Denominator_**: Cumulative number of children on ART, excluding deceased and transfers and those who had a negative PCR result.
> **_Calculation method_**: Pediatric HIV+ patients on ART excluding deceased, transfers and those who had a negative PCR result.
> **_Disaggregation_**: 6, 12, 24, 48, 60 months

