### PR TITLE
Health-Qual-Paed-2

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/childrenHivAndPlacedOnArt.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/childrenHivAndPlacedOnArt.sql
@@ -12,14 +12,15 @@ SELECT
 FROM
 isanteplus.patient p
 WHERE
-  p.patient_id IN (
+  p.vih_status = '1' -- HIV+ patient
+  AND p.patient_id IN (
     SELECT phv.patient_id
     FROM isanteplus.health_qual_patient_visit phv
     LEFT JOIN isanteplus.patient_prescription pp
     ON phv.patient_id = pp.patient_id
     WHERE (
-        DATE(phv.visit_date) BETWEEN :startDate AND :endDate
-        OR (DATE(pp.visit_date) BETWEEN :startDate AND :endDate AND pp.rx_or_prophy = 138405)
+        DATE(phv.visit_date) BETWEEN :startDate AND :endDate AND encounter_type IN (9,10) -- Paeds initial and followup encounter types
+        OR (DATE(pp.visit_date) BETWEEN :startDate AND :endDate)
       )
       AND phv.age_in_years <= 14
   )


### PR DESCRIPTION
- When computing the denominator, added the Peads Initial and Followup
encounters to the query filter.

----
Indicator definition
--

> **Proportion of children tested positive for HIV and placed on ART during the selected period.**
> **_Numerator_**: Number of HIV+ children placed on ART during the selected period.
> **_Calculation method_**: Pediatric HIV+ patients on ART excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the selected period.
> **_Denominator_**: Number of children who were diagnosed with HIV and seen in
> the clinic during the selected period, excluding those who have suspended treatment, those who had a negative PCR result, transfers and deceased.
> **_Calculation method_**: Pediatric HIV+ patients excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the selected period.

@ningosi @ckemar 