### PR TITLE
Health-Qual-Paed-3

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/pediatricHivAndReceivedCotrimoxazoleProphylaxis.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/pediatricHivAndReceivedCotrimoxazoleProphylaxis.sql
@@ -2,7 +2,6 @@ SELECT
   COUNT( DISTINCT CASE WHEN (
       p.gender = 'F'
       AND p.patient_id
-      AND pp.rx_or_prophy = 163768
       AND pp.drug_id = 105281
       AND (pp.visit_date BETWEEN :startDate AND :endDate)
     ) THEN p.patient_id else null END
@@ -10,7 +9,6 @@ SELECT
   COUNT( DISTINCT CASE WHEN (
       p.gender = 'M'
       AND p.patient_id
-      AND pp.rx_or_prophy = 163768
       AND pp.drug_id = 105281
       AND (pp.visit_date BETWEEN :startDate AND :endDate)
     ) THEN p.patient_id else null END
@@ -27,29 +25,30 @@ FROM isanteplus.patient p
 LEFT JOIN isanteplus.patient_prescription pp
 ON p.patient_id = pp.patient_id
 WHERE
-  p.patient_id IN (
+  p.vih_status = '1' -- HIV+ patient
+  AND p.patient_id IN (
     SELECT phv.patient_id
     FROM isanteplus.health_qual_patient_visit phv
     WHERE (
-        DATE(phv.visit_date) BETWEEN :startDate AND :endDate
-        OR (DATE(pp.visit_date) BETWEEN :startDate AND :endDate AND pp.rx_or_prophy = 138405)
+        DATE(phv.visit_date) BETWEEN :startDate AND :endDate AND encounter_type IN (9,10) -- Paeds initial and followup encounter types
+        OR (DATE(pp.visit_date) BETWEEN :startDate AND :endDate)
       )
-      AND phv.age_in_years <= 14
+      AND phv.age_in_years <= 14 -- Paediatric
+      AND TIMESTAMPDIFF(WEEK, p.birthdate, phv.visit_date) > 4 -- Older than 4 weeks of age
   )
   AND p.patient_id NOT IN (
     SELECT discon.patient_id
     FROM isanteplus.discontinuation_reason discon
     WHERE discon.reason IN (159,1667,159492)
   )
-  AND (
-    TIMESTAMPDIFF(MONTH, p.birthdate,:endDate) <= 18
-    OR p.patient_id NOT IN (
-      SELECT plab.patient_id
-      FROM isanteplus.patient_laboratory plab
-      WHERE
-        plab.test_done = 1
-        AND plab.test_id = 844
-        AND plab.test_result = 1302
-    )
+  AND p.patient_id NOT IN ( -- Negative PCR Result after 18 Months of Age
+	SELECT plab.patient_id
+	FROM isanteplus.patient_laboratory plab
+	WHERE
+		plab.test_done = 1
+		AND plab.test_id = 844
+		AND plab.test_result = 1302
+		AND TIMESTAMPDIFF(MONTH, p.birthdate,:endDate) >= 18 
   )
-  AND TIMESTAMPDIFF(WEEK,p.birthdate,:endDate) >= 4;
+  
+  


### PR DESCRIPTION
- When computing the denominator, Modified filter for excluding patients
older than 4 weeks and patients with negative PCR results after 18 Months
of Age
----
Indicator definition
--

> **Proportion of children exposed to or infected with HIV who received cotrimoxazole prophylaxis during the selected period.**
> **_Numerator_**: Number of children exposed to and infected with HIV followed in clinic who are eligible for cotrimoxazole prophylaxis and received it during the reporting period.
> **_Calculation method_**: Pediatric HIV+ patients (4 or more weeks old) excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result after 18 months of age, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the selected period and who have received cotrimoxazole prophylaxis. 
> **_Denominator_**: Number of children exposed to and infected with HIV older than 4 weeks of age followed in clinic during the selected period, excluding discontinued cases and those who have had a negative PCR after 18 months of age
> **_Calculation method_**: Pediatric HIV+ patients (older than 4 weeks of age) excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result after 18 months of age, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the selected period.

cc @ningosi @ckemar 