### PR TITLE
Health-Qual-Paed-4

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/pediatricBenefitedFromAnAdherence.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/pediatricBenefitedFromAnAdherence.sql
@@ -32,10 +32,9 @@ WHERE
     LEFT JOIN isanteplus.patient_prescription pp
     ON phv.patient_id = pp.patient_id
     WHERE (
-        DATE(phv.visit_date) BETWEEN SUBDATE(:currentDate, INTERVAL 3 MONTH) AND :currentDate
+        DATE(phv.visit_date) BETWEEN SUBDATE(:currentDate, INTERVAL 3 MONTH) AND :currentDate AND phv.encounter_type IN (9,10) -- Paeds initial and followup encounter types
         OR (
           DATE(pp.visit_date) BETWEEN SUBDATE(:currentDate, INTERVAL 3 MONTH) AND :currentDate
-          AND pp.rx_or_prophy = 138405
         )
       )
       AND phv.age_in_years <= 14 -- An child


### PR DESCRIPTION
- When computing the denominator, added the peads Initial and followup
encounters to the query filter
----
Indicator definition
--

> **Proportion of HIV+ children on ART who have had an adherence evaluation during the last 3 months.**
> **_Numerator_** : Number of HIV+ children on ART who have had an adherence evaluation (a pill count or completed questionnaire saved to their chart) in the last 3 months.
> **_Calculation method_**: Pediatric HIV+ patients on ART excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the last three months and who benefited from an adherence evaluation. 
> **_Denominator_**: Number of children on ART who had at least one medical consultation during the last 3 months, excluding discontinued cases and those who have had a negative PCR.
> **_Calculation method_**: Pediatric HIV+ patients on ART excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the last three months.

cc @ningosi @ckemar 