### PR TITLE
Health-Qual-Paed-5

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/childrenOnArtWhoAreConsideredAdherent.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/childrenOnArtWhoAreConsideredAdherent.sql
@@ -26,10 +26,9 @@ LEFT JOIN isanteplus.patient_prescription pp
 WHERE
   pv.adherence_evaluation IS NOT NULL
   AND (
-      DATE(pv.visit_date) BETWEEN SUBDATE(:currentDate, INTERVAL 3 MONTH) AND :currentDate
+      DATE(pv.visit_date) BETWEEN SUBDATE(:currentDate, INTERVAL 3 MONTH) AND :currentDate AND pv.encounter_type IN (9,10) -- Paeds initial and followup encounter types
     OR (
       DATE(pp.visit_date) BETWEEN SUBDATE(:currentDate, INTERVAL 3 MONTH) AND :currentDate
-      AND pp.rx_or_prophy = 138405
     )
   )
   AND p.patient_id IN (	-- on ART for 3 months or more


### PR DESCRIPTION
- When computing the denominator, added the peads Initial and followup
encounter types to the query filter

----
Indicator definition
--
> **Proportion of HIV+ children on ART who are considered adherent**
> **_Numerator_**: Cumulative number of pediatric patients enrolled in ART for more than 3 months who have an adherence level ≥ 95%.
> **_Calculation method_**: Pediatric HIV+ patients on ART excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the last three months and have an adherence level ≥ 905%. See Figure 15 in the Adult section.
> **_Denominator_**: Cumulative number of pediatric patients enrolled in ART for more than 3 months who have had an adherence evaluation in the last 3 months, excluding discontinued cases and those who have had a negative PCR.
> **_Calculation method_**: Pediatric HIV+ patients on ART excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the last three months
AND have an adherence evaluation completed.

cc @ningosi @ckemar 