### PR TITLE
Health-Qual-Paed-6

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHIVChildrenTestedForTB.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHIVChildrenTestedForTB.sql
@@ -29,7 +29,6 @@ FROM
     isanteplus.patient p
 WHERE
     p.vih_status = 1
-    AND TIMESTAMPDIFF(MONTH, p.birthdate, :endDate) >= 6
     AND p.patient_id IN (
         SELECT pv.patient_id
         FROM isanteplus.health_qual_patient_visit pv
@@ -37,6 +36,7 @@ WHERE
             pv.encounter_type IN ('9') -- pediatric first HIV visit
             AND pv.visit_date BETWEEN :startDate AND :endDate -- the date of first visit
             AND pv.age_in_years <= 14
+    		AND TIMESTAMPDIFF(MONTH, p.birthdate, pv.visit_date) >= 6
     )
     AND p.patient_id NOT IN (
         SELECT discon.patient_id


### PR DESCRIPTION
- When computing the denominator, changed the 6Month age calculation's effective date from the parameter "endDate" to Visits Table's "visit_date" column

----
Indicator definition
--

> **Proportion of HIV+ children tested for TB at enrolment during the selected period**
> **_Numerator_**: Number of children 6 months of age and older who are assessed for TB at enrollment during the selected period.
> **_Calculation method_**: Pediatric HIV+ patients older than 6 months of age excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had an HIV First Pediatric Visit with the TB section completed indicating a non-null result during the selected period.
> **_Denominator_**: Number of HIV-infected children age 6-months and older who are enrolled in care during the selected period, excluding discontinued cases and those who have had a negative PCR.
> **_Calculation method_**: Pediatric HIV+ patients older than 6 months of age excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had an HIV First Pediatric Visit during the selected period.

cc @ningosi @ckemar 