### PR TITLE
Health-Qual-Paed-7

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHIVChildrenOlderThanOneYearOfAgeReceivedINH.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHIVChildrenOlderThanOneYearOfAgeReceivedINH.sql
@@ -31,19 +31,19 @@ FROM
         ON p.patient_id = pp.patient_id
 WHERE
     p.vih_status = 1
-    AND TIMESTAMPDIFF(YEAR, p.birthdate, :endDate) BETWEEN 1 AND 14
     AND p.patient_id IN ( -- Pediatric Rx
         SELECT patient_id
         FROM isanteplus.patient_prescription AS innerpp
         WHERE
         DATE(innerpp.visit_date) BETWEEN :startDate AND :endDate
-        AND innerpp.rx_or_prophy = 138405
     )
     AND p.patient_id IN ( -- ‌HIV First Pediatric Visit OR Pediatric Follow‐up‌
-        SELECT phv.patient_id
-        FROM isanteplus.pediatric_hiv_visit phv, isanteplus.health_qual_patient_visit pv
-        WHERE pv.encounter_id = phv.encounter_id
+        SELECT pv.patient_id
+        FROM isanteplus.health_qual_patient_visit pv
+        WHERE pv.encounter_id 
         AND DATE(pv.visit_date) BETWEEN :startDate AND :endDate
+        AND pv.encounter_type IN (9,10)
+    	AND TIMESTAMPDIFF(YEAR, p.birthdate, pv.visit_date) BETWEEN 1 AND 14
     )
     AND p.patient_id NOT IN ( -- exclude active TB
         SELECT pv.patient_id


### PR DESCRIPTION
- When computing the denominator, changed the age calculation effective date from parameter "endDate" to Visit's table "visit_date" column

----
Indicator definition
--

> **Proportion of eligible (TB-negative) HIV+ children older than 1 year of age who received INH chemoprophylaxis during the selected period.**
> **_Numerator_**: Number of HIV+ children older than 1 year of age enrolled at the clinic during the selected period who received INH prophylaxis.
> **_Calculation method_**: Pediatric HIV+ patients older than 1 year of age excluding deceased, those who discontinued treatment, transfers, those who had a negative PCR result, and those who have active TB who have had received INH prophylaxis during the selected period
> (HIV First Pediatric Visit or Pediatric Follow-up AND Pediatric Rx). 
> Note: Eligibility criteria for INH prophylaxis for HIV+ children are as follows: 1) contact with a case of active TB regardless of age (but no active TB); 2) HIV+ child who is older than 1 year of age (but no active TB).
> **_Denominator_**: Number of HIV+ children older than 1 year of age enrolled at the clinic during the selected period, excluding discontinued cases and those who have active TB.
> **_Calculation method_**: Pediatric HIV+ patients older than 1 year of age excluding deceased, those who discontinued treatment, transfers, those who had a negative PCR result, and those who have active TB who have had at least one visit (HIV First Pediatric Visit or Pediatric
> Follow-up AND Pediatric Rx) during the selected period.

cc @ningosi @ckemar 