### PR TITLE
Health-Qual-Paed-12

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/pediatricReceivedPcrTest.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/pediatricReceivedPcrTest.sql
@@ -42,16 +42,36 @@ WHERE
         LEFT JOIN isanteplus.patient_prescription pp
             ON phv.patient_id = pp.patient_id
         WHERE
-            DATE(phv.visit_date) BETWEEN :startDate AND :endDate
-            OR (
-                DATE(pp.visit_date) BETWEEN :startDate AND :endDate
-                AND pp.rx_or_prophy = 138405
+            (
+	            DATE(phv.visit_date) BETWEEN :startDate AND :endDate AND phv.encounter_type IN (9,10) -- Paeds initial and followup encounter types
+	            OR 
+	            DATE(pp.visit_date) BETWEEN :startDate AND :endDate
             )
+		    AND TIMESTAMPDIFF(MONTH, p.birthdate, phv.visit_date) <= 12
+		    AND TIMESTAMPDIFF(WEEK, p.birthdate, phv.visit_date) >= 4
+	)
+	
+	AND p.patient_id IN ( -- Eligible for PCR
+		SELECT DISTINCT patient_id -- Exposed to HIV between 4 weeks and 12 months
+        FROM isanteplus.pediatric_hiv_visit v
+        WHERE 
+            actual_vih_status = 1405 ANd v.encounter_date <= :endDate
+            AND TIMESTAMPDIFF(WEEK, p.birthdate, v.encounter_date) >= 4
+            AND TIMESTAMPDIFF(MONTH, p.birthdate, v.encounter_date) <= 12
+		UNION		
+        SELECT DISTINCT pvt.patient_id -- Exposed to HIV between 12 and 18 months with a +ve HIV antigen test
+        FROM isanteplus.pediatric_hiv_visit v
+        INNER JOIN isanteplus.virological_tests pvt ON v.patient_id = pvt.patient_id
+        WHERE 
+            pvt.answer_concept_id = 1030
+            AND pvt.test_result = 703
+            AND pvt.encounter_date <= :endDate	
+            AND v.encounter_date <= :endDate		
+            AND v.actual_vih_status = 1405	
+            AND TIMESTAMPDIFF(MONTH, p.birthdate, v.encounter_date) BETWEEN 12 AND 18
 	)
 	AND p.patient_id NOT IN (
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon
         WHERE discon.reason IN (159, 1667, 159492)
-	)
-    AND TIMESTAMPDIFF(MONTH, p.birthdate, :endDate) <= 12
-    AND TIMESTAMPDIFF(WEEK, p.birthdate, :endDate) >= 4;
+	);


### PR DESCRIPTION
- When computing the denominator, added criteria for PCR eligibility

----
Indicator definition
--

> **Proportion of HIV-exposed infants between 4 weeks old and 18 months old who have received a PCR test during the selected period**
> **_Numerator_**: Number of HIV-exposed infants between 4 weeks old and 18 months old who have received a PCR test at the clinic during the selected period.
> **_Calculation method_**: HIV-exposed children between 4 weeks old and 18 months old excluding discontinued cases, deceased, and transfers, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) and who had a PCR test done during the selected period.
> **_Denominator_**: Number of HIV-exposed infants between 4 weeks old and 18 months old who were seen at the clinic during the selected period.
> **_Calculation method_**: HIV-exposed children between 4 weeks old and 18 months old who are eligible for a PCR test excluding discontinued cases, deceased, and transfers, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) during the selected period.
> Note: Eligibility criteria for at least one PCR test: 1) children who are exposed to HIV between 4 weeks and 12 months of age or 2) children who are exposed to HIV between 12 and 18 months old who have a positive HIV antigen test.

cc @ningosi @ckemar 