### PR TITLE
Health-Qual-Paed-13

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/pediatricNegativePcrTest.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/pediatricNegativePcrTest.sql
@@ -47,16 +47,16 @@ WHERE
         LEFT JOIN isanteplus.patient_prescription pp
         ON phv.patient_id = pp.patient_id
         WHERE
-            DATE(phv.visit_date) BETWEEN :startDate AND :endDate
-            OR (
-                DATE(pp.visit_date) BETWEEN :startDate AND :endDate
-                AND pp.rx_or_prophy = 138405
+            (
+	            DATE(phv.visit_date) BETWEEN :startDate AND :endDate
+	            OR 
+	            DATE(pp.visit_date) BETWEEN :startDate AND :endDate
             )
+		    AND TIMESTAMPDIFF(MONTH, p.birthdate, phv.visit_date) <= 18
+		    AND TIMESTAMPDIFF(WEEK, p.birthdate, phv.visit_date) >= 4
     )
     AND p.patient_id NOT IN (
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon
         WHERE discon.reason IN (159, 1667, 159492)
-    )
-    AND TIMESTAMPDIFF(MONTH, p.birthdate, :endDate) <= 18
-    AND TIMESTAMPDIFF(WEEK, p.birthdate, :endDate) >= 4;
+    );


### PR DESCRIPTION
- When computing the denominator, changed the age calculation effective date from parameter "endDate" to Visits Table "visit_date" column

----
Indicator definition
--

> **Proportion of HIV-exposed infants who had a negative PCR test result during the selected period.**
> **_Numerator_**: Number of HIV-exposed infants between 4 weeks and 18 months old whose most recent PCR test result is negative.
> **_Calculation method_**: HIV-exposed children between 4 weeks old and 18 months old excluding discontinued cases, deceased, and transfers, who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx) and whose latest PCR test was negative during the selected period.
> **_Denominator_**: Number of HIV-exposed infants between 4 weeks and 18 months old who were seen at the clinic and had a PCR test completed during the selected period.
> **_Calculation method_**: HIV-exposed children between 4 weeks old and 18 months old excluding discontinued cases, deceased, and transfers, who have had a PCR test (HIV First Pediatric Visit or Pediatric Follow-up or  Pediatric Rx) during the selected period.

cc @ningosi @ckemar 