### PR TITLE
Health-Qual-Paed-14

### DIFF
--- a/api/src/main/java/org/openmrs/module/isanteplusreports/healthqual/HealthQualManager.java
+++ b/api/src/main/java/org/openmrs/module/isanteplusreports/healthqual/HealthQualManager.java
@@ -49,7 +49,8 @@ public class HealthQualManager {
 			HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_10_INDICATOR_UUID,
 			HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_11_INDICATOR_UUID,
 			HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_12_INDICATOR_UUID,
-			HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_13_INDICATOR_UUID
+			HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_13_INDICATOR_UUID,
+            HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_14_INDICATOR_UUID
 	};
 	
 	private Map<String, HealthQualIndicatorOption> options = new HashMap<>();

--- a/api/src/main/java/org/openmrs/module/isanteplusreports/healthqual/util/HealthQualReportsConstants.java
+++ b/api/src/main/java/org/openmrs/module/isanteplusreports/healthqual/util/HealthQualReportsConstants.java
@@ -67,6 +67,8 @@ public final class HealthQualReportsConstants {
 
     static final String PEDIATRIC_13_INDICATOR_SQL = "pediatricNegativePcrTest.sql";
 
+    static final String PEDIATRIC_14_INDICATOR_SQL = "earlyInfantDiagnosis.sql";
+    
     // Indicator message properties
     static final String ADULT = "isanteplusreports.adult";
 
@@ -132,6 +134,8 @@ public final class HealthQualReportsConstants {
 
     static final String PEDIATRIC_13_INDICATOR_MESSAGE = PEDIATRIC + 13;
 
+    static final String PEDIATRIC_14_INDICATOR_MESSAGE = PEDIATRIC + 14;
+    
     // indicators' UUIDs
     public static final String NUMBER_OF_ACTIVE_PATIENTS_BY_SEX_UUID = "69679207-04a8-4fb9-b3ad-75a8dd5c0a58";
 
@@ -192,4 +196,7 @@ public final class HealthQualReportsConstants {
     public static final String HEALTH_QUAL_PEDIATRIC_12_INDICATOR_UUID = "2baddb89-084b-4152-b9ce-3b9826e79495";
 
     public static final String HEALTH_QUAL_PEDIATRIC_13_INDICATOR_UUID = "28a71811-5511-40eb-8ca5-79464cd3448a";
+    
+    public static final String HEALTH_QUAL_PEDIATRIC_14_INDICATOR_UUID = "1399880c-93cd-4c02-871b-80885ef8c0f2";
+    
 }

--- a/api/src/main/java/org/openmrs/module/isanteplusreports/healthqual/util/RegisterAllHealthQualReports.java
+++ b/api/src/main/java/org/openmrs/module/isanteplusreports/healthqual/util/RegisterAllHealthQualReports.java
@@ -58,6 +58,8 @@ import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualRep
 import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualReportsConstants.PEDIATRIC_12_INDICATOR_SQL;
 import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualReportsConstants.PEDIATRIC_13_INDICATOR_MESSAGE;
 import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualReportsConstants.PEDIATRIC_13_INDICATOR_SQL;
+import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualReportsConstants.PEDIATRIC_14_INDICATOR_MESSAGE;
+import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualReportsConstants.PEDIATRIC_14_INDICATOR_SQL;
 import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualReportsConstants.PEDIATRIC_1_INDICATOR_MESSAGE;
 import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualReportsConstants.PEDIATRIC_1_INDICATOR_SQL;
 import static org.openmrs.module.isanteplusreports.healthqual.util.HealthQualReportsConstants.PEDIATRIC_2_INDICATOR_MESSAGE;
@@ -124,6 +126,7 @@ public class RegisterAllHealthQualReports {
         healthQualPediatricHivAndArtProphy();
         healthQualPediatricReceivedPcrTest();
         healthQualPediatricNegativePcrTest();
+        healthQualEarlyInfantDiagnosis();
     }
 
     private static void numberOfPatientsBySex() {
@@ -276,6 +279,11 @@ public class RegisterAllHealthQualReports {
             HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_13_INDICATOR_UUID);
     }
 
+    private static void healthQualEarlyInfantDiagnosis() {
+        registerHealthEqualReportWithStartAndEndDateParams(PEDIATRIC_14_INDICATOR_SQL, PEDIATRIC_14_INDICATOR_MESSAGE,
+            HealthQualReportsConstants.HEALTH_QUAL_PEDIATRIC_14_INDICATOR_UUID);
+    }
+    
     private static void registerHealthEqualReportWithStartAndEndDateParams(String sql, String messageProperties, String uuid) {
         SqlDataSetDefinition sqlData = sqlDataSetDefinitionWithResourcePath(sql, messageProperties, messageProperties, HEALTH_QUAL_REPORTS_RESOURCE_PATH);
         sqlData.addParameter(START_DATE);

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -143,6 +143,7 @@ isanteplusreports.pediatric10=Proportion of HIV-exposed or infected children who
 isanteplusreports.pediatric11=Proportion of HIV-exposed infants who received ART prophylaxis during the selected period.
 isanteplusreports.pediatric12=Proportion of HIV-exposed infants between 4 weeks old and 12 months old who have received a PCR test
 isanteplusreports.pediatric13=Proportion of HIV-exposed infants who had a negative PCR test result during the selected period.
+isanteplusreports.pediatric14=Early Infant Diagnosis.
 isanteplusreports.death_on_art=List of patients Death on ART 
 isanteplusreports.stopped_on_art=List of patients Stopped on ART
 isanteplusreports.transfered_on_art=List of patients Transfered on ART

--- a/api/src/main/resources/messages_es.properties
+++ b/api/src/main/resources/messages_es.properties
@@ -53,3 +53,4 @@ isanteplusreports.pediatric10=Proportion of HIV‐exposed or infected children w
 isanteplusreports.pediatric11=Proportion of HIV-exposed infants who received ART prophylaxis during the selected period.
 isanteplusreports.pediatric12=Proportion of HIV-exposed infants between 4 weeks old and 12 months old who have received a PCR test
 isanteplusreports.pediatric13=Proportion of HIV-exposed infants who had a negative PCR test result during the selected period.
+isanteplusreports.pediatric14=Early Infant Diagnosis (EID).

--- a/api/src/main/resources/messages_fr.properties
+++ b/api/src/main/resources/messages_fr.properties
@@ -141,6 +141,7 @@ isanteplusreports.pediatric10=Proportion d'enfants exposés ou infectés au VIH 
 isanteplusreports.pediatric11=Proportion d'enfants exposés au VIH ayant bénéficié de la prophylaxie aux ARV au cours de la période d'analyse.
 isanteplusreports.pediatric12=Proportion d'enfants exposés au VIH âgés de 4 semaines à 12 mois ayant bénéficié d'un test PCR diagnostic au cours de la période d'analyse.
 isanteplusreports.pediatric13=Proportion d'enfants exposés au VIH ayant un test PCR négatif au cours de la période d'analyse.
+isanteplusreports.pediatric14=Le diagnostic pr�coce du VIH/SIDA p�diatrique.
 isanteplusreports.death_on_art=Liste des patients décédés sous ARV
 isanteplusreports.stopped_on_art=Liste des patients arrêtés sous ARV
 isanteplusreports.transfered_on_art=Liste des patients Transférés sous ARV

--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/earlyInfantDiagnosis.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/earlyInfantDiagnosis.sql
@@ -1,0 +1,78 @@
+SELECT
+	COUNT( DISTINCT CASE WHEN (
+        p.gender = 'F'
+            AND p.patient_id IN (
+                SELECT plab.patient_id
+                FROM isanteplus.patient_laboratory plab
+                WHERE
+                    plab.test_done = 1
+                    AND plab.test_id = 844
+                    AND plab.test_result  IS NOT NULL
+                    AND DATE(plab.date_test_done) <= :endDate
+            )
+        ) THEN p.patient_id else null END
+	) AS 'femaleNumerator',
+    COUNT( DISTINCT CASE WHEN (
+        p.gender = 'M'
+        AND p.patient_id IN (
+            SELECT plab.patient_id
+            FROM isanteplus.patient_laboratory plab
+            WHERE
+                plab.test_done = 1
+                AND plab.test_id = 844
+                AND plab.test_result IS NOT NULL
+                AND DATE(plab.date_test_done) <= :endDate
+            )
+        ) THEN p.patient_id else null END
+	) AS 'maleNumerator',
+	COUNT( DISTINCT CASE WHEN (
+			p.gender = 'F'
+		) THEN p.patient_id else null END
+	) AS 'femaleDenominator',
+    COUNT( DISTINCT CASE WHEN (
+			p.gender = 'M'
+		) THEN p.patient_id else null END
+	) AS 'maleDenominator'
+FROM
+	isanteplus.patient p
+WHERE
+	(
+		p.patient_id IN (
+	        SELECT phv.patient_id -- between 4 weeks and 12 months of age who have had a HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx
+	        FROM isanteplus.health_qual_patient_visit phv
+	        LEFT JOIN isanteplus.patient_prescription pp
+	            ON phv.patient_id = pp.patient_id
+	        WHERE
+	        	(
+		            DATE(phv.visit_date) BETWEEN :startDate AND :endDate AND phv.encounter_type IN (9,10) -- Paeds initial and followup encounter types
+		            OR 
+		            DATE(pp.visit_date) BETWEEN :startDate AND :endDate
+	            )
+			    AND TIMESTAMPDIFF(MONTH, p.birthdate, phv.visit_date) <= 12
+			    AND TIMESTAMPDIFF(WEEK, p.birthdate, phv.visit_date) >= 4
+		)
+		OR 
+		p.patient_id IN (
+	        SELECT phv.patient_id -- between 12 and 18 months of age who have had HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx AND a positive rapid test
+	        FROM isanteplus.health_qual_patient_visit phv
+	        LEFT JOIN isanteplus.patient_prescription pp
+	            ON phv.patient_id = pp.patient_id
+	        INNER JOIN isanteplus.patient_laboratory plab 
+	        	ON plab.patient_id = phv.patient_id 
+	        WHERE
+	        	(
+		            DATE(phv.visit_date) BETWEEN :startDate AND :endDate AND phv.encounter_type IN (9,10) -- Paeds initial and followup encounter types
+		            OR 
+		            DATE(pp.visit_date) BETWEEN :startDate AND :endDate -- Prescription
+	            )
+			    AND plab.test_id = 1040 -- Rapid HIV Test
+			    AND plab.test_result = 703 -- Positive
+				AND DATE(plab.date_test_done) BETWEEN :startDate AND :endDate
+			    AND TIMESTAMPDIFF(MONTH, p.birthdate, phv.visit_date) BETWEEN 12 AND 18
+		)
+	)
+	AND p.patient_id NOT IN (
+        SELECT discon.patient_id
+        FROM isanteplus.discontinuation_reason discon
+        WHERE discon.reason IN (159, 1667, 159492)
+	)

--- a/messages.properties
+++ b/messages.properties
@@ -143,6 +143,7 @@ isanteplusreports.pediatric10=Proportion of HIV-exposed or infected children who
 isanteplusreports.pediatric11=Proportion of HIV-exposed infants who received ART prophylaxis during the selected period.
 isanteplusreports.pediatric12=Proportion of HIV-exposed infants between 4 weeks old and 12 months old who have received a PCR test
 isanteplusreports.pediatric13=Proportion of HIV-exposed infants who had a negative PCR test result during the selected period.
+isanteplusreports.pediatric14=Early Infant Diagnosis(EID).
 isanteplusreports.death_on_art=List of patients Death on ART 
 isanteplusreports.stopped_on_art=List of patients Stopped on ART
 isanteplusreports.transfered_on_art=List of patients Transfered on ART

--- a/messages_es.properties
+++ b/messages_es.properties
@@ -53,3 +53,4 @@ isanteplusreports.pediatric10=Proportion of HIV‐exposed or infected children w
 isanteplusreports.pediatric11=Proportion of HIV-exposed infants who received ART prophylaxis during the selected period.
 isanteplusreports.pediatric12=Proportion of HIV-exposed infants between 4 weeks old and 12 months old who have received a PCR test
 isanteplusreports.pediatric13=Proportion of HIV-exposed infants who had a negative PCR test result during the selected period.
+isanteplusreports.pediatric14=Early Infant Diagnosis(EID)

--- a/messages_fr.properties
+++ b/messages_fr.properties
@@ -141,6 +141,7 @@ isanteplusreports.pediatric10=Proportion d'enfants exposés ou infectés au VIH 
 isanteplusreports.pediatric11=Proportion d'enfants exposés au VIH ayant bénéficié de la prophylaxie aux ARV au cours de la période d'analyse.
 isanteplusreports.pediatric12=Proportion d'enfants exposés au VIH âgés de 4 semaines à 12 mois ayant bénéficié d'un test PCR diagnostic au cours de la période d'analyse.
 isanteplusreports.pediatric13=Proportion d'enfants exposés au VIH ayant un test PCR négatif au cours de la période d'analyse.
+isanteplusreports.pediatric14=Le diagnostic pr�coce du VIH/SIDA p�diatrique.
 isanteplusreports.death_on_art=Liste des patients décédés sous ARV
 isanteplusreports.stopped_on_art=Liste des patients arrêtés sous ARV
 isanteplusreports.transfered_on_art=Liste des patients Transférés sous ARV


### PR DESCRIPTION
Added the Early Infant Diagnosis Indicator to the Health Qual report

----
Indicator definition
--
**Numerator**: Number of children between 4 weeks- and 1 year-old, and those between 12 and 18 months-old who had an early infant diagnosis via PCR test at any time before the close of the reporting period.
**Calculation method**: Pediatric patient between 4 weeks and 12 months of age, and those between 12 and 18 months of age who have had a HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx and who have had a PCR test during the selected period. 
**Denominator**: Number of children between 4 weeks- and 1 year-old, and those between 12 and 18 months-old who were seen in the clinic during the reporting period and had a positive rapid HIV test result. 
**Calculation method**: Pediatric patients between 4 weeks and 12 months of age who have had a HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx and those between 12 and 18 months of age who have had HIV First Pediatric Visit or Pediatric Follow-up or Pediatric Rx AND a positive rapid test during the selected period. 

cc @ningosi @ckemar 