### PR TITLE
Health-Qual-Paed-8

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHIVChildrenYoungerThanOneYearOfAgeReceivedINH.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfHIVChildrenYoungerThanOneYearOfAgeReceivedINH.sql
@@ -28,7 +28,50 @@ LEFT JOIN isanteplus.pediatric_hiv_visit phv
 ON p.patient_id = phv.patient_id
 WHERE
     (p.vih_status = 1 -- HIV Positive
-    OR  phv.actual_vih_status = 1405)  -- HIV Exposed Infant
+    OR  p.patient_id IN ( -- Include exposed children
+      SELECT DISTINCT pv.patient_id
+        FROM isanteplus.health_qual_patient_visit pv
+        WHERE
+        pv.patient_id NOT IN (    -- Condition E
+          SELECT DISTINCT plab.patient_id
+          FROM isanteplus.patient_laboratory plab
+          WHERE
+            plab.test_done = 1
+            AND plab.test_id = 844  -- PCR
+            AND plab.test_result = 1301 -- positive
+            AND plab.date_test_done BETWEEN :startDate AND :endDate)
+        AND pv.patient_id NOT IN ( -- Condition E positive virology test
+            SELECT DISTINCT pvt.patient_id
+            FROM isanteplus.virological_tests pvt
+            WHERE answer_concept_id = 1030
+            AND test_result = 703
+            AND pvt.encounter_date BETWEEN :startDate AND :endDate)
+        AND pv.age_in_years < 14 -- An child
+        AND ( pv.patient_id IN (  -- Condition D
+            SELECT DISTINCT pp.patient_id
+            FROM isanteplus.patient_prescription pp
+            WHERE pp.rx_or_prophy = 163768 -- prophylaxis
+            AND drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs))
+          OR pv.patient_id IN ( -- Condition B
+            SELECT DISTINCT patient_id
+            FROM isanteplus.pediatric_hiv_visit
+            WHERE actual_vih_status = 1405) -- HIV EXPOSED
+          OR pv.patient_id IN ( -- Condition A PCR result
+            SELECT DISTINCT plab.patient_id
+            FROM isanteplus.patient_laboratory plab
+            WHERE plab.test_done = 1
+              AND plab.test_id = 844  -- PCR
+              AND plab.test_result = 1302 -- negative
+              AND plab.date_test_done < :endDate)
+          OR pv.patient_id IN ( -- Condition A virology test
+            SELECT DISTINCT pvt.patient_id
+            FROM isanteplus.virological_tests pvt
+            WHERE answer_concept_id = 1030
+            AND test_result = 664
+            AND pvt.encounter_date  < :endDate)
+	      )
+	    ) 
+    ) 
     AND p.patient_id IN (
         SELECT pv.patient_id
         FROM isanteplus.health_qual_patient_visit pv


### PR DESCRIPTION
When computing the denominator:
- changed the age calculation effective date from reporting "endDate" to the "visit_date"
- corrected the query to exclude Active TB patients (as per the indicator definition)
- Added the check for HIV exposed infants

----
Indicator definition
--
**Proportion of HIV-exposed or infected children younger than 1 year of age who received INH chemoprophylaxis during the selected period.**
**_Numerator_**: Number of HIV-exposed or infected children younger than 1 year of age who had contact with active TB and were placed on INH prophylaxis.
**_Calculation method_**: Eligible pediatric HIV+ patients or HIV-exposed children less than 1 year of age excluding deceased, those who discontinued treatment, transfers, and those who have active TB who received INH prophylaxis (HIV First Pediatric Visit or Pediatric Follow-up AND Pediatric Rx) during the selected period. 
**_Denominator_**: Number of HIV-exposed or infected children younger than 1 year of age who had contact with active TB, excluding all discontinued cases and deceased.
**_Calculation method_**: Eligible pediatric HIV+ patients or HIV-exposed children less than 1 year of age excluding deceased, those who discontinued treatment, transfers, and those who have active TB who have had at least one visit (HIV First Pediatric Visit or Pediatric Follow-up AND Pediatric Rx) during the selected period.
Note: Eligibility for this age group: contact with a case of active TB.

cc @ckemar @ningosi
