### PR TITLE
Health-Qual-paed-9

### DIFF
--- a/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfChildrenWithNutritionalAssessment.sql
+++ b/api/src/main/resources/org/openmrs/module/isanteplusreports/sql/healthQualReports/proportionOfChildrenWithNutritionalAssessment.sql
@@ -81,7 +81,7 @@ WHERE
         SELECT phv.patient_id
         FROM isanteplus.health_qual_patient_visit phv
     WHERE (
-        DATE(phv.visit_date) BETWEEN :startDate AND :endDate
+        DATE(phv.visit_date) BETWEEN :startDate AND :endDate AND phv.encounter_type IN (9,10) -- Paeds initial and followup encounter types
       )
       AND phv.age_in_years <= 14
     )


### PR DESCRIPTION
When computing the denominator, added the peads Initial and followup
encounter types to the query filter

----
Indicator definition
--
**Proportion of HIV-exposed or HIV+ children who have had a nutritional assessment during the selected period.**
**_Numerator_**: Number of HIV-exposed or infected children who have the necessary data to evaluate their nutritional status (weight and height or MUAC and head circumference) saved in their chart during the selected period.
**_Calculation method_**: HIV-exposed children or pediatric HIV+ patients excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, have had at least one visit (HIV First
Pediatric Visit or Pediatric Follow-up) and who have had a nutritional assessment completed during the selected period.
**_Denominator_**: Number of HIV-exposed or infected who have had at least one medical consultation during the selected period, excluding discontinued cases and those who have had a negative PCR.
**_Calculation method_**: HIV-exposed children or pediatric HIV+ patients excluding deceased, those who discontinued treatment, transfers and those who had a negative PCR result, who have had at least one visit (HIV
First Pediatric Visit or Pediatric Follow-up) during the selected period.
